### PR TITLE
Add : 전략 이름 입력 Input 추가

### DIFF
--- a/src/components/atoms/Input/index.tsx
+++ b/src/components/atoms/Input/index.tsx
@@ -1,0 +1,20 @@
+import { HTMLAttributes } from 'react';
+
+interface IInputProps extends HTMLAttributes<HTMLInputElement> {
+  name: HTMLInputElement['name'];
+  max?: number;
+  maxLength?: number;
+  placeholder?: string;
+  type?: 'text' | 'number' | 'email' | 'password';
+  value: string;
+}
+
+function Input(props: IInputProps) {
+  const { max, maxLength, type = 'text', ...otherProps } = props;
+
+  // number - max, 그 외 - maxLength 사용
+  if (type === 'number') return <input max={max} {...otherProps} />;
+  return <input maxLength={maxLength} {...otherProps} />;
+}
+
+export default Input;

--- a/src/components/molecule/StrategyTitle/index.tsx
+++ b/src/components/molecule/StrategyTitle/index.tsx
@@ -1,0 +1,78 @@
+import { HTMLAttributes } from 'react';
+import styled from 'styled-components';
+
+import Input from 'components/atoms/Input';
+
+import { flex, theme } from 'styles';
+
+interface IStrategyTitleProps extends HTMLAttributes<HTMLInputElement> {
+  value: string;
+}
+
+function StrategyTitle({ value, onChange }: IStrategyTitleProps) {
+  return (
+    <Wrapper>
+      <StyledInput name="strategyTitle" placeholder="전략 이름을 입력해주세요." value={value} onChange={onChange} />
+      <Button disabled={!value} type="button">
+        전략 저장
+      </Button>
+    </Wrapper>
+  );
+}
+
+export default StrategyTitle;
+
+const Wrapper = styled.div`
+  ${flex('', '')}
+  column-gap: 60px;
+`;
+
+const StyledInput = styled(Input)`
+  width: 100%;
+  font-size: 28px;
+  font-weight: 700;
+  border-bottom: 1px solid ${theme.white};
+  color: ${theme.white};
+
+  ::placeholder {
+    color: ${theme.white};
+  }
+
+  :focus {
+    ::-webkit-input-placeholder,
+    textarea:focus::-webkit-input-placeholder {
+      /* WebKit browsers */
+      color: transparent;
+    }
+
+    :-moz-placeholder,
+    textarea:focus:-moz-placeholder {
+      /* Mozilla Firefox 4 to 18 */
+      color: transparent;
+    }
+
+    ::-moz-placeholder,
+    textarea:focus::-moz-placeholder {
+      /* Mozilla Firefox 19+ */
+      color: transparent;
+    }
+
+    :-ms-input-placeholder,
+    textarea:focus:-ms-input-placeholder {
+      /* Internet Explorer 10+ */
+      color: transparent;
+    }
+  }
+`;
+
+const Button = styled.button`
+  padding: 0 30px;
+  border-radius: 5px;
+  background: ${theme.orange};
+  white-space: nowrap;
+
+  :disabled {
+    background: ${theme.button.disabled};
+    color: ${theme.black};
+  }
+`;

--- a/src/pages/Allocation/index.tsx
+++ b/src/pages/Allocation/index.tsx
@@ -1,15 +1,30 @@
+import { ChangeEvent, useState } from 'react';
+import styled from 'styled-components';
+
 import Layout from 'components/organism/Layout';
 import Text from 'components/atoms/Text';
+import StrategyTitle from 'components/molecule/StrategyTitle';
 
 function Allocation() {
+  const [strategyTitle, setStrategyTitle] = useState('');
+
+  const handleStrategyTitleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setStrategyTitle(e.target.value);
+  };
+
   return (
     <Layout>
-      <Text.Large>자산배분 설정</Text.Large>
-      <Text.Medium>자산배분 알고리즘</Text.Medium>
-      <Text.Medium>주기 리밸런싱</Text.Medium>
-      <Text.Medium>밴드 리밸런싱</Text.Medium>
+      <Wrapper>
+        <StrategyTitle value={strategyTitle} onChange={handleStrategyTitleChange} />
+        <Text.Large>자산배분 설정</Text.Large>
+        <Text.Medium>자산배분 알고리즘</Text.Medium>
+        <Text.Medium>주기 리밸런싱</Text.Medium>
+        <Text.Medium>밴드 리밸런싱</Text.Medium>
+      </Wrapper>
     </Layout>
   );
 }
 
 export default Allocation;
+
+const Wrapper = styled.div``;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -4,6 +4,10 @@ const theme = {
   white: '#fcfcfc',
   lightGray: '#9f9f9f',
   darkGray: '#6e6e6e',
+  orange: '#ec6126',
+  button: {
+    disabled: '#3e3e3e',
+  },
 };
 
 export default theme;


### PR DESCRIPTION
### PR Type

- [ ] 버그 수정
- [x] 신규 기능
- [ ] 기타 (기타인 경우 내용 입력 : )

### 해당 PR의 목적
- 전략 타이틀 입력 Input UI 구현

![image](https://user-images.githubusercontent.com/98295004/213390949-171bcf55-45ef-42e7-ab89-419456da1d8b.png)

### 중점적으로 봤으면 하는 부분
- 전략 타이틀 입력 Input은 여러 곳에서 쓰이니 추후 유의할 것
   - 백테스트, 포트폴리오 추출 => recoil
   - 자산배분 => useState