### PR TITLE
Add : Button 공통 컴포넌트

### DIFF
--- a/src/components/atoms/Button/index.tsx
+++ b/src/components/atoms/Button/index.tsx
@@ -1,0 +1,53 @@
+import { HTMLAttributes, ReactNode } from 'react';
+import styled from 'styled-components';
+import { theme } from 'styles';
+
+interface IButtonProps extends HTMLAttributes<HTMLButtonElement> {
+  children: ReactNode;
+  background?: string;
+  color?: string;
+  disabled?: boolean;
+  padding?: string;
+  type?: 'button' | 'submit';
+  onClick: () => void;
+}
+
+function Button({
+  children,
+  background = theme.orange,
+  color = theme.black,
+  disabled = false,
+  padding,
+  type = 'button',
+  onClick,
+}: IButtonProps) {
+  return (
+    <StyledButton
+      background={background}
+      color={color}
+      disabled={disabled}
+      padding={padding}
+      type={type}
+      onClick={onClick}
+    >
+      {children}
+    </StyledButton>
+  );
+}
+
+export default Button;
+
+type IButtonStyle = Omit<IButtonProps, 'children'>;
+
+const StyledButton = styled.button<IButtonStyle>`
+  border-radius: 5px;
+  background: ${(props) => props.background};
+  color: ${(props) => props.color};
+  padding: ${(props) => props.padding};
+  white-space: nowrap;
+
+  :disabled {
+    background: ${theme.button.disabled};
+    color: ${theme.black};
+  }
+`;

--- a/src/components/molecule/StrategyTitle/index.tsx
+++ b/src/components/molecule/StrategyTitle/index.tsx
@@ -2,6 +2,7 @@ import { HTMLAttributes } from 'react';
 import styled from 'styled-components';
 
 import Input from 'components/atoms/Input';
+import Button from 'components/atoms/Button';
 
 import { flex, theme } from 'styles';
 
@@ -13,7 +14,7 @@ function StrategyTitle({ value, onChange }: IStrategyTitleProps) {
   return (
     <Wrapper>
       <StyledInput name="strategyTitle" placeholder="전략 이름을 입력해주세요." value={value} onChange={onChange} />
-      <Button disabled={!value} type="button">
+      <Button disabled={!value} padding="0 30px" type="button" onClick={() => {}}>
         전략 저장
       </Button>
     </Wrapper>
@@ -65,14 +66,14 @@ const StyledInput = styled(Input)`
   }
 `;
 
-const Button = styled.button`
-  padding: 0 30px;
-  border-radius: 5px;
-  background: ${theme.orange};
-  white-space: nowrap;
+// const Button = styled.button`
+//   padding: 0 30px;
+//   border-radius: 5px;
+//   background: ${theme.orange};
+//   white-space: nowrap;
 
-  :disabled {
-    background: ${theme.button.disabled};
-    color: ${theme.black};
-  }
-`;
+//   :disabled {
+//     background: ${theme.button.disabled};
+//     color: ${theme.black};
+//   }
+// `;

--- a/src/components/organism/Layout/Layout/index.tsx
+++ b/src/components/organism/Layout/Layout/index.tsx
@@ -30,4 +30,5 @@ const Container = styled.div`
 
 const Body = styled.main`
   width: 1020px;
+  padding: 40px 0;
 `;


### PR DESCRIPTION
### PR Type

- [ ] 버그 수정
- [x] 신규 기능
- [ ] 기타 (기타인 경우 내용 입력 : )

### 해당 PR의 목적
- 전략 저장 버튼 UI 구현
- 공통 컴포넌트 Button 생성

<img width="122" alt="image" src="https://user-images.githubusercontent.com/98295004/213450395-60e14570-8ef5-4a10-93ff-d68a7e86835f.png">

### 중점적으로 봤으면 하는 부분
- style을 color, padding 개별 프롭으로 넘겨줘야 하나?
  저번에 style={...} 으로 넘겨줬더니 인라인 스타일 쓰지 말라고 해서
  어떻게 스타일 커스텀을 할 수 있을지 고민이다.