### PR TITLE
Add : label 숫자 0 붙여주는 fillzero util 추가

### DIFF
--- a/src/pages/Allocation/components/AssetClassList/index.tsx
+++ b/src/pages/Allocation/components/AssetClassList/index.tsx
@@ -7,6 +7,7 @@ import { Dropdown, Select } from 'components/molecule';
 import { STOCK_LIST } from './data';
 import { flex } from 'styles';
 import { IAssetClass } from 'types/allocation';
+import fillZero from 'utils/fillZero';
 
 function AssetClassList() {
   const [assetClassList, setAssetClassList] = useState<IAssetClass[]>([]);
@@ -76,7 +77,7 @@ function AssetClassList() {
             </Dropdown.List>
             <Dropdown.Trigger>
               <Select>
-                <Select.Label htmlFor={`assetClass-${idx}`}>{`자산 ${idx + 1}`}</Select.Label>
+                <Select.Label htmlFor={`assetClass-${idx}`}>{`자산 ${fillZero(idx)}`}</Select.Label>
                 <Select.Input title={`assetClass-${idx}`} value={assetClass.name} onClick={handleSelectInputClick} />
               </Select>
             </Dropdown.Trigger>

--- a/src/utils/fillZero.ts
+++ b/src/utils/fillZero.ts
@@ -1,0 +1,3 @@
+const fillZero = (value: number) => `${value + 1 < 10 ? '0' : ''}${value + 1}`;
+
+export default fillZero;


### PR DESCRIPTION
### PR Type
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 기타 (기타인 경우 내용 입력 : )

### 해당 PR의 목적
- label 숫자에 10 미만일 경우 0 붙여주는 util 함수 추가 (fillZero)
```typescript
const fillZero = (value: number) => `${value + 1 < 10 ? '0' : ''}${value + 1}`;
```
<img width="499" alt="image" src="https://user-images.githubusercontent.com/98295004/213901333-ec95f139-4cce-435d-a1db-d4bdb8065c77.png">


### 중점적으로 봤으면 하는 부분
- x
