### PR TITLE
Fix : 자산 검색어 입력 시 결과 리셋 버그 해결

### DIFF
--- a/src/pages/Allocation/components/AssetList/components/Asset/index.tsx
+++ b/src/pages/Allocation/components/AssetList/components/Asset/index.tsx
@@ -42,14 +42,12 @@ function Asset({
     setSearchValue(value);
   };
 
-  if (!getSuccess) return null;
-
   return (
     <Container>
       <AssetDropdown>
         <Dropdown.List isOpen={isOpen}>
           <SearchBar placeholder="검색어를 입력하세요." title={title} onChange={handleSearchInputChange} />
-          <StockList rows={stockListData} title={title} onItemClick={onDropdownItemClick} />
+          {getSuccess ? <StockList rows={stockListData} title={title} onItemClick={onDropdownItemClick} /> : null}
         </Dropdown.List>
         <Dropdown.Trigger>
           <Select>


### PR DESCRIPTION
### PR Type

- [x] 버그 수정
- [ ] 신규 기능
- [ ] 기타 (기타인 경우 내용 입력 : )

### 해당 PR의 목적
- 자산 검색어 입력 시 결과가 리셋되는 버그 해결

### 중점적으로 봤으면 하는 부분
- get api 새로 호출할 때 SearchBar 컴포넌트까지 없어져서 
  searchValue가 초기화 되고 있었음.
  -> getSuccess 조건부 렌더링 위치를 변경해주었다!!
