### PR TITLE
Add : 최상단 헤더 등급 선택 기능

### DIFF
--- a/src/components/molecule/Tabs/index.tsx
+++ b/src/components/molecule/Tabs/index.tsx
@@ -1,0 +1,44 @@
+import { HTMLAttributes, useState, Children } from 'react';
+import styled from 'styled-components';
+
+import { Button } from 'components/atoms';
+import { flex, theme } from 'styles';
+
+interface ITabsProps extends HTMLAttributes<HTMLDivElement> {}
+
+function Tabs({ children, ...restProps }: ITabsProps) {
+  const [activeTabIndex, setActiveTabIndex] = useState(0);
+
+  const handleTabClick = (tabIndex: number) => {
+    setActiveTabIndex(tabIndex);
+  };
+
+  return (
+    <Container {...restProps}>
+      {children &&
+        Children.toArray(children).map((child, index) => (
+          <TabBtn isActive={index === activeTabIndex} onClick={() => handleTabClick(index)}>
+            {child}
+          </TabBtn>
+        ))}
+    </Container>
+  );
+}
+
+export default Tabs;
+
+interface ITabBtnStyle {
+  isActive: boolean;
+}
+
+const Container = styled.div`
+  ${flex('', '')}
+`;
+
+const TabBtn = styled(Button)<ITabBtnStyle>`
+  background: ${(props) => (props.isActive ? theme.orange : theme.lightBlack)};
+  span {
+    color: ${(props) => (props.isActive ? theme.black : theme.white)};
+    font-weight: ${(props) => (props.isActive ? 500 : 300)};
+  }
+`;

--- a/src/components/molecule/index.tsx
+++ b/src/components/molecule/index.tsx
@@ -5,3 +5,4 @@ export { default as SearchBar } from './SearchBar';
 export { default as VirtualizedList } from './VirtualizedList';
 export { default as Calendar } from './Calendar';
 export { default as Modal } from './Modal';
+export { default as Tabs } from './Tabs';

--- a/src/components/organism/Header/TopMenu/index.tsx
+++ b/src/components/organism/Header/TopMenu/index.tsx
@@ -1,25 +1,38 @@
 import { Link } from 'react-router-dom';
+import { useSetRecoilState } from 'recoil';
 import styled from 'styled-components';
 
 import Text from 'components/atoms/Text';
 import Logo from 'components/atoms/Logo';
 import WrapperLayout from 'components/organism/Layout/WrapperLayout';
+import { Tabs } from 'components/molecule';
 
+import { strategyState } from 'recoil/allocation';
 import { flex, theme } from 'styles';
 
 function TopMenu() {
+  const setStrategy = useSetRecoilState(strategyState);
+
+  const handleTabClick = (level: '초급' | '중급' | '고급') => {
+    setStrategy((prev) => ({ ...prev, level }));
+  };
+
   return (
     <Container>
       <WrapperLayout>
         <Logo path="/" />
-        <button type="button">초급</button>
-        <button type="button">중급</button>
-        <button type="button">고급</button>
-        <Link to="/">
-          <Text.Regular color={theme.red} weight={700}>
-            로그인 하러가기
-          </Text.Regular>
-        </Link>
+        <UserMenu>
+          <Tabs>
+            <Tab onClick={() => handleTabClick('초급')}>초급</Tab>
+            <Tab onClick={() => handleTabClick('중급')}>중급</Tab>
+            <Tab onClick={() => handleTabClick('고급')}>고급</Tab>
+          </Tabs>
+          <Link to="/">
+            <Text.Regular color={theme.red} weight={700}>
+              로그인 하러가기
+            </Text.Regular>
+          </Link>
+        </UserMenu>
       </WrapperLayout>
     </Container>
   );
@@ -31,4 +44,13 @@ const Container = styled.div`
   ${flex('center', '')};
   width: 100%;
   padding: 30px 0 20px;
+`;
+
+const UserMenu = styled.div`
+  ${flex('', 'center')};
+  column-gap: 30px;
+`;
+
+const Tab = styled.div`
+  padding: 5px 20px;
 `;


### PR DESCRIPTION
### PR Type
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 기타 (기타인 경우 내용 입력 : )

### 해당 PR의 목적
- 최상단 헤더 / 등급 선택 기능 추가

### 중점적으로 봤으면 하는 부분
- Tabs 공통 컴포넌트를 만들어보았습니다. (Tabs안에 <Tab>...</Tab> 여러 개 넣는 방식)

Tabs
- handleTabClick : 활성화된 index를 변경. 버튼 스타일이 바뀝니다 
```typescript
<Container {...restProps}>
    {children &&
      Children.toArray(children).map((child, index) => (
        <TabBtn isActive={index === activeTabIndex} onClick={() => handleTabClick(index)}>
          {child}
        </TabBtn>
      ))}
</Container>
```
usage
- handleTabClick : 전략 객체 (strategy)의 level을 변경
```typescript
<Tabs>
    <Tab onClick={() => handleTabClick('초급')}>초급</Tab>
    <Tab onClick={() => handleTabClick('중급')}>중급</Tab>
    <Tab onClick={() => handleTabClick('고급')}>고급</Tab>
</Tabs>
```

<img width="848" alt="image" src="https://user-images.githubusercontent.com/98295004/214486284-5bb5e31f-f875-4466-9f95-b76ed9c7833b.png">
