### PR TITLE
Fix : 전략 이름 (StrategyName) sticky 안되는 버그 해결

### DIFF
--- a/src/pages/Allocation/components/AllocStrategyName/index.tsx
+++ b/src/pages/Allocation/components/AllocStrategyName/index.tsx
@@ -8,6 +8,7 @@ import { StrategyName } from 'components/organism';
 
 import { assetListState, strategyState } from 'recoil/allocation';
 import { ALLOC_ALGORITHM, ALLOC_REBALANCING, ALLOC_LEVEL } from 'pages/Allocation/constant';
+import { Z_INDEX } from 'styles';
 
 function AllocStrategyName() {
   const [showCompleteModal, setShowCompleteModal] = useState(false);
@@ -41,20 +42,20 @@ function AllocStrategyName() {
   };
 
   return (
-    <Modal>
-      <Modal.Trigger>
-        <StrategyName value={strategyName} onChange={handleStrategyNameChange} onSave={handleStrategySave} />
-      </Modal.Trigger>
-      <Modal.Dimmed isOpen={showCompleteModal} onClose={toggleCompleteModal} />
-      <Modal.Contents isOpen={showCompleteModal} onClose={toggleCompleteModal}>
-        <Modal.Title>전략 저장 완료</Modal.Title>
-        <Description>
-          <Text.Regular weight={300}>{`"${strategyName}" 전략 저장이 완료되었습니다.`}</Text.Regular>
-          <Text.Regular weight={300}>저장된 전략은 마이페이지-전략 조회에서 조회 가능합니다.</Text.Regular>
-        </Description>
-        <Modal.Button onClick={toggleCompleteModal}>확인</Modal.Button>
-      </Modal.Contents>
-    </Modal>
+    <Container>
+      <StrategyName value={strategyName} onChange={handleStrategyNameChange} onSave={handleStrategySave} />
+      <Modal>
+        <Modal.Dimmed isOpen={showCompleteModal} onClose={toggleCompleteModal} />
+        <Modal.Contents isOpen={showCompleteModal} onClose={toggleCompleteModal}>
+          <Modal.Title>전략 저장 완료</Modal.Title>
+          <Description>
+            <Text.Regular weight={300}>{`"${strategyName}" 전략 저장이 완료되었습니다.`}</Text.Regular>
+            <Text.Regular weight={300}>저장된 전략은 마이페이지-전략 조회에서 조회 가능합니다.</Text.Regular>
+          </Description>
+          <Modal.Button onClick={toggleCompleteModal}>확인</Modal.Button>
+        </Modal.Contents>
+      </Modal>
+    </Container>
   );
 }
 
@@ -62,4 +63,10 @@ export default AllocStrategyName;
 
 const Description = styled(Modal.Description)`
   row-gap: 10px;
+`;
+
+const Container = styled.div`
+  position: sticky;
+  top: 131px;
+  z-index: ${Z_INDEX.header};
 `;


### PR DESCRIPTION
### PR Type
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 기타 (기타인 경우 내용 입력 : )

### 해당 PR의 목적
- 버그 수정 : 전략 이름 (StrategyName) sticky 안되고 최상단 헤더 위로 넘어감

### 중점적으로 봤으면 하는 부분
- 원인 : 부모 컴포넌트 변경
   Modal.Trigger 안에 StrategyName을 넣으면서
   부모 컴포넌트가 바뀌어 버리는 바람에 고정이 제대로 안됨

 - 고민 : Modal에 `position : sticky` 속성 주기에는 스타일을 너무 한정 시켜버리는 것 같음 
 
 - 해결 : Modal.Trigger를 삭제하고 StrategyName을 Modal 외부로 옮김 
 
[수정 전]
![1_before_AdobeExpress](https://user-images.githubusercontent.com/98295004/214491718-fdd28a80-c3c4-4306-9891-690043afa63a.gif)

[수정 후]  
![2_after_AdobeExpress](https://user-images.githubusercontent.com/98295004/214491728-9c9271fd-7789-4e03-b44b-316ab1c38702.gif)
