### PR TITLE
Add : ensureInRange 유틸 함수 추가 (input number value 에러 핸들링)

### DIFF
--- a/src/components/atoms/Input/Input/components/Value.tsx
+++ b/src/components/atoms/Input/Input/components/Value.tsx
@@ -5,8 +5,6 @@ import { theme, fontSize } from 'styles';
 interface IValueProps extends HTMLAttributes<HTMLInputElement> {
   title: HTMLInputElement['title'];
   maxLength?: number;
-  max?: string;
-  min?: string;
   placeholder?: string;
   readOnly?: boolean;
   type?: 'text' | 'number' | 'email' | 'password';

--- a/src/components/atoms/Input/NumberInput/index.tsx
+++ b/src/components/atoms/Input/NumberInput/index.tsx
@@ -2,31 +2,22 @@ import { ChangeEvent } from 'react';
 import styled from 'styled-components';
 
 import Input from 'components/atoms/Input/Input';
+
 import { theme } from 'styles';
 
 interface INumberInputProps {
   label?: string;
-  max?: string;
-  min?: string;
   subMessage?: string;
   value: string;
   title: string;
   onChange: (e: ChangeEvent<HTMLInputElement>) => void;
 }
 
-function NumberInput({ label, max, min, subMessage, value, title, onChange }: INumberInputProps) {
+function NumberInput({ label, subMessage, value, title, onChange }: INumberInputProps) {
   return (
     <StyledInput>
       {label && <Input.Label htmlFor={title}>{label}</Input.Label>}
-      <Input.Value
-        max={max}
-        min={min}
-        textAlign="center"
-        title={title}
-        type="number"
-        value={value}
-        onChange={onChange}
-      />
+      <Input.Value textAlign="center" title={title} type="number" value={value} onChange={onChange} />
       <Input.Right>
         <Percentage>%</Percentage>
       </Input.Right>

--- a/src/components/molecule/Tabs/index.tsx
+++ b/src/components/molecule/Tabs/index.tsx
@@ -17,7 +17,7 @@ function Tabs({ children, ...restProps }: ITabsProps) {
     <Container {...restProps}>
       {children &&
         Children.toArray(children).map((child, index) => (
-          <TabBtn isActive={index === activeTabIndex} onClick={() => handleTabClick(index)}>
+          <TabBtn key={`tab-${index}`} isActive={index === activeTabIndex} onClick={() => handleTabClick(index)}>
             {child}
           </TabBtn>
         ))}

--- a/src/pages/Allocation/components/AllocSetting/index.tsx
+++ b/src/pages/Allocation/components/AllocSetting/index.tsx
@@ -8,6 +8,7 @@ import { Dropdown, Select } from 'components/molecule';
 import { strategyState } from 'recoil/allocation';
 import { ALLOC_ALGORITHM_LIST, ALLOC_REBALANCING_LIST } from 'pages/Allocation/constant';
 
+import { ensureInRange } from 'utils';
 import { flex } from 'styles';
 
 function AllocSetting() {
@@ -19,7 +20,7 @@ function AllocSetting() {
 
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     const { title, value } = e.target;
-    if (title === 'band') return setStrategy((prev) => ({ ...prev, [title]: value }));
+    if (title === 'band') return setStrategy((prev) => ({ ...prev, [title]: ensureInRange(value, 0, 100) }));
   };
 
   const handleSelectInputClick = (e: MouseEvent<HTMLDivElement>) => {
@@ -88,8 +89,6 @@ function AllocSetting() {
       </Dropdown>
       <NumberInput
         label="밴드 리밸런싱"
-        max="100"
-        min="0"
         subMessage="0 ~ 100까지 입력할 수 있습니다. (0 입력시 비활성화)"
         title="band"
         value={band}

--- a/src/pages/Allocation/components/AssetList/components/Asset/index.tsx
+++ b/src/pages/Allocation/components/AssetList/components/Asset/index.tsx
@@ -58,8 +58,6 @@ function Asset({
       </AssetDropdown>
       <NumberInput
         label="비중"
-        max="100"
-        min="0"
         subMessage="0 ~ 100까지 입력할 수 있습니다."
         title={`asset-${index}`}
         value={asset.ratio}

--- a/src/pages/Allocation/components/AssetList/index.tsx
+++ b/src/pages/Allocation/components/AssetList/index.tsx
@@ -7,6 +7,7 @@ import Asset from './components/Asset';
 
 import { assetListState } from 'recoil/allocation';
 import { flex } from 'styles';
+import { ensureInRange } from 'utils';
 
 function AssetList() {
   const [showDropdown, setShowDropdown] = useState<{ [key: string]: boolean }>({});
@@ -35,7 +36,7 @@ function AssetList() {
 
   const handleRatioInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     const { title, value } = e.target;
-    updateAsset('ratio', title, value);
+    updateAsset('ratio', title, ensureInRange(value, 0, 100));
   };
 
   const updateAsset = (key: 'name' | 'ratio', title: string, value: string) => {

--- a/src/recoil/allocation.ts
+++ b/src/recoil/allocation.ts
@@ -7,7 +7,7 @@ export const strategyState = atom<IStrategy>({
   default: {
     algo: '전략배분 (정적자산배분)',
     allocRebalancing: '',
-    band: '0',
+    band: '',
     endDate: dayjs().format('YYYY.MM.DD'),
     level: '중급',
     startDate: dayjs().subtract(20, 'year').format('YYYY.MM.DD'),

--- a/src/utils/checkBlank.ts
+++ b/src/utils/checkBlank.ts
@@ -1,5 +1,6 @@
-// T는 string | number
-// 빈 문자열 이거나, '0'일 때 빈 값으로 간주
+// 기능 : value 배열을 전달 받아, value가 빈 문자열 이거나, '0'일 때 빈 값으로 간주한다.
+// 리턴 : 빈 값이 없으면 true, 있으면 false
+// 타입 : T는 string | number
 const checkBlank = <T>(array: T[]) => {
   const isValid = !array.some((el) => Number(el) === 0 || !el);
   return isValid;

--- a/src/utils/ensureInRange.ts
+++ b/src/utils/ensureInRange.ts
@@ -1,0 +1,14 @@
+// 기능1 : value를 min ~ max 사이에서 입력될 수 있도록 한다.
+// 기능2 : hasPrefixZero를 통해 '01' -> '1'로 변환한다.
+
+const ensureInRange = (value: string, min: number, max: number): string => {
+  const hasPrefixZero = value.startsWith('0');
+  const num = Number(hasPrefixZero ? value.replaceAll('0', '') : value);
+
+  if (num < min) return String(min);
+  if (num > max) return String(max);
+
+  return String(num);
+};
+
+export default ensureInRange;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,3 +2,4 @@ export * from './date';
 export * from './fillZero';
 export * from './regex';
 export { default as checkBlank } from './checkBlank';
+export { default as ensureInRange } from './ensureInRange';


### PR DESCRIPTION
### PR Type

- [ ] 버그 수정
- [x] 신규 기능
- [ ] 기타 (기타인 경우 내용 입력 : )

### 해당 PR의 목적
- ensureInRange 구현
   - type="number'인 인풋의 value 에러 핸들링 해주는 유틸 함수
   - 숫자만 입력 가능 (한글, 영어 불가) 
   - min~max 사이에서만 입력 가능
 
![3_number input error handling](https://user-images.githubusercontent.com/98295004/214505083-530e05dc-8dfe-4b33-929a-d8a077687dad.gif)

### 중점적으로 봤으면 하는 부분
- max, min 속성은 form submit 할 때 작동한다고 해서
   input value를 실시간으로 체크해주는 ensureInRange 함수를 만들었다.
   
- 01처럼 0으로 시작하는 value도 걸러주기 위해 hasPrefixZero 라는 변수를 선언했다.

```typescript
const ensureInRange = (value: string, min: number, max: number): string => {
  const hasPrefixZero = value.startsWith('0');
  const num = Number(hasPrefixZero ? value.replaceAll('0', '') : value);

  if (num < min) return String(min);
  if (num > max) return String(max);

  return String(num);
};

export default ensureInRange;
```